### PR TITLE
fix(lib): change deprecated Buffer allocation

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -65,7 +65,7 @@ export class Core {
         let data = this.encodeParams(params);
         let protocol = (env.protocol === 'http' ? this.http : this.https);
         Util.extend(true, headers, {
-            'Authorization': 'Basic ' + new Buffer(env.api_key + ':').toString('base64'),
+            'Authorization': 'Basic ' + Buffer.from(env.api_key + ':').toString('base64'),
             'Accept': 'application/json',
             'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
             "Content-Length": data.length,


### PR DESCRIPTION
Hello folks,

Little PR to fix a deprecated use of the buffer constructor, should use Buffer.from 😄

Here is the node message for info :
```
DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```