### PR TITLE
default callback to undefined

### DIFF
--- a/src/request_wrapper.ts
+++ b/src/request_wrapper.ts
@@ -38,7 +38,7 @@ export class RequestWrapper {
       return this;
     }
 
-    public request(callBack, envOptions?): Q.Promise<any> {
+    public request(callBack = undefined, envOptions?): Q.Promise<any> {
         let env = {};
         let jsonConstructor =  {}.constructor;
         Util.extend(true, env, this.envArg);


### PR DESCRIPTION
request currently does not allow you to skip providing a callback to the request function. In the logic, it knows how to handle undefined for promises, but we have to provide the undefined value explicitly