### PR TITLE
add configuration option to allow throwing of errors instead of objects

### DIFF
--- a/src/core_error.ts
+++ b/src/core_error.ts
@@ -1,0 +1,11 @@
+class CoreError extends Error {
+  constructor(
+    message: string,
+    public readonly type: string,
+    public readonly httpStatusCode: number,
+    public readonly errorCode: string,
+    public readonly details?: any
+  ) {
+    super(message)
+  }
+}

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -6,6 +6,7 @@ let environment = {
     clientVersion: 'v2.4.0',
     port: 443,
     timemachineWaitInMillis: 3000,
-    exportWaitInMillis: 3000
+    exportWaitInMillis: 3000,
+    useErrorObject: false
 }
 module.exports = environment


### PR DESCRIPTION
fixes #21

Idea is that we can configure this behaviour:

```ts
const c = new ChargeBee()

c.configure({
  site: '***',
  api_key: '***',
  useErrorObject: true
})
```