### PR TITLE
fix: move `@types/q` to dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,50 +1,50 @@
 {
-   "name": "chargebee-typescript",
-   "version": "2.23.0",
-   "description": "A library in typescript for integrating with Chargebee.",
-   "keywords": [
-      "payments",
-      "billing",
-      "subscription",
-      "chargebee",
-      "chargebee-typescript"
-   ],
-   "homepage": "http://github.com/chargebee/chargebee-typescript",
-   "author": "Navaneedhan <navaneedhan@chargebee.com> (https://www.chargebee.com)",
-   "main": "lib/chargebee.js",
-   "types": "lib/chargebee.d.ts",
-   "files": [
-      "lib/**/*"
-   ],
-   "scripts": {
-      "tsc": "tsc --pretty"
-   },
-   "dependencies": {
-      "q": ">=1.0.1"
-   },
-   "devDependencies": {
-      "@types/node": "^13.13.52",
-      "@types/q": "^1.5.2",
-      "typescript": "^3.9.3"
-   },
-   "directories": {
-      "lib": "./lib"
-   },
-   "repository": {
-      "type": "git",
-      "url": "http://github.com/chargebee/chargebee-typescript.git"
-   },
-   "engines": {
-      "node": ">=8.0.0"
-   },
-   "bugs": {
-      "url": "http://support.chargebee.com",
-      "email": "support@chargebee.com"
-   },
-   "licenses": [
-      {
-         "type": "MIT",
-         "url": "http://github.com/chargebee/chargebee-typescript/blob/master/LICENSE"
-      }
-   ]
+  "name": "chargebee-typescript",
+  "version": "2.23.0",
+  "description": "A library in typescript for integrating with Chargebee.",
+  "keywords": [
+    "payments",
+    "billing",
+    "subscription",
+    "chargebee",
+    "chargebee-typescript"
+  ],
+  "homepage": "http://github.com/chargebee/chargebee-typescript",
+  "author": "Navaneedhan <navaneedhan@chargebee.com> (https://www.chargebee.com)",
+  "main": "lib/chargebee.js",
+  "types": "lib/chargebee.d.ts",
+  "files": [
+    "lib/**/*"
+  ],
+  "scripts": {
+    "tsc": "tsc --pretty"
+  },
+  "dependencies": {
+    "@types/q": "^1.5.2",
+    "q": ">=1.0.1"
+  },
+  "devDependencies": {
+    "@types/node": "^13.13.52",
+    "typescript": "^3.9.3"
+  },
+  "directories": {
+    "lib": "./lib"
+  },
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/chargebee/chargebee-typescript.git"
+  },
+  "engines": {
+    "node": ">=8.0.0"
+  },
+  "bugs": {
+    "url": "http://support.chargebee.com",
+    "email": "support@chargebee.com"
+  },
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "http://github.com/chargebee/chargebee-typescript/blob/master/LICENSE"
+    }
+  ]
 }


### PR DESCRIPTION
when `@types/q` is listed in `devDependencies` then it is not installed when `chargebee-typescript` is installed.  Projects that use `chargebee-typescript` can have problems with the typescript compilation without this package and it can be very frustrating to debug.