### PR TITLE
fix: Add missing `feature_type` to SubscriptionEntitlement

### DIFF
--- a/src/resources/subscription_entitlement.ts
+++ b/src/resources/subscription_entitlement.ts
@@ -9,6 +9,7 @@ export class SubscriptionEntitlement extends Model {
   public subscription_id: string;
   public feature_id?: string;
   public feature_name?: string;
+  public feature_type?: 'switch' | 'quantity' | 'range' | 'custom';
   public feature_unit?: string;
   public value?: string;
   public name?: string;


### PR DESCRIPTION
Add missing `feature_type` to SubscriptionEntitlement, which is present in the API response