### PR TITLE
Release typescript SDK v2.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### v2.51.0 ( 2025-05-22)
+* * * 
+
+### Release Fixes: 
+* Resolved issue with empty package being published to npm.
+
 ### v2.50.0 (2025-07-18) 
 * * * 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
    "name": "chargebee-typescript",
-   "version": "2.50.0",
+   "version": "2.51.0",
    "description": "A library in typescript for integrating with Chargebee.",
    "keywords": [
       "payments",

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -3,7 +3,7 @@ let environment = {
     hostSuffix: '.chargebee.com',
     apiPath: '/api/v2',
     timeout: 80000,
-    clientVersion: 'v2.50.0',
+    clientVersion: 'v2.51.0',
     port: 443,
     timemachineWaitInMillis: 3000,
     exportWaitInMillis: 3000


### PR DESCRIPTION
## Release PR

SDK: typescript
Version: 2.51.0

This PR contains the latest changes from cb-client-libs/typescript.